### PR TITLE
glob options now a property of main options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
     EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits,
+    extend = require('util')._extend,
     FTP = require('ftp'),
     _ = require('lodash'),
     glob = require('glob'),
@@ -60,10 +61,11 @@ Client.prototype.connect = function (callback) {
 
 Client.prototype.upload = function (patterns, dest, options, uploadCallback) {
     options = _.defaults(options || {}, this.options);
+    var globOptions = options.globOptions;
 
     var paths, files, dirs, toDelete = [], ftp = this.ftp;
 
-    paths = this._glob(patterns);
+    paths = this._glob(patterns, globOptions);
     paths = this._clean(paths, options.baseDir);
     paths = this._stat(paths);
 
@@ -451,9 +453,11 @@ Client.prototype._checkTimezone = function (cb) {
     }.bind(this));
 }
 
-Client.prototype._glob = function (patterns) {
+Client.prototype._glob = function (patterns, globOptions) {
     var include = [],
         exclude = [];
+
+    options = extend(globOptions, {nonull: false});
 
     if (!_.isArray(patterns)) {
         patterns = [patterns];
@@ -461,9 +465,9 @@ Client.prototype._glob = function (patterns) {
 
     patterns.forEach(function (pattern) {
         if (pattern.indexOf('!') === 0) {
-            exclude = exclude.concat(glob.sync(pattern.substring(1), {nonull: false}) || []);
+            exclude = exclude.concat(glob.sync(pattern.substring(1), options) || []);
         } else {
-            include = include.concat(glob.sync(pattern, {nonull: false}) || []);
+            include = include.concat(glob.sync(pattern, options) || []);
         }
     });
 


### PR DESCRIPTION
Options now have property globObtions to allow for /*\* glob option to find .htacess and other dot files too.

```
{
            baseDir: commit_dir + '/' + diffs.commit,
            overwrite: 'all',
            globOptions: {
                dot: true
            }
        }
```
