### PR TITLE
Do not put an empty file

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -424,7 +424,7 @@ Client.prototype._checkTimezone = function (cb) {
 
     async.series([
         function (next) {
-            return ftp.put(new Buffer(''), '.timestamp', function (err) {
+            return ftp.put(new Buffer('blank'), '.timestamp', function (err) {
                 if (err) log(err, 'debug');
                 next();
             });


### PR DESCRIPTION
On a customer (Windows based) FTP I found that creating an empty Buffer lead to a strange error, where the ftp client simply fails silently during the getServerTime procedure.

Just writing something in the temp file fixed the issue