### PR TITLE
bug fix for Client.js

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,7 +37,7 @@ Client = module.exports = function (config, options) {
 
     this.ftp = new FTP();
     this.ftp.on('error', function (err) {
-        throw new Error(err);
+        return new Error(err);
     });
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -58,6 +58,15 @@ Client.prototype.connect = function (callback) {
     this.ftp.connect(this.config || {});
 };
 
+Client.prototype.delete = function(dest, callback) {
+  console.log('--- det file deletion path', dest);
+  this.ftp.delete(dest, function (err) {
+      if (err) log(err, 'debug');
+      console.log('deleted');
+      callback();
+  }.bind(this))
+};
+
 Client.prototype.upload = function (patterns, dest, options, uploadCallback) {
     options = _.defaults(options || {}, this.options);
 
@@ -279,7 +288,6 @@ Client.prototype.download = function (source, dest, options, downloadCallback) {
             // if (list && list.length > 0) {
                 // _.each(list.splice(1, list.length - 1), function (file) {
                 _.each(list, function (file) {
-                  console.log('--- file', file);
                     if (file.name !== '.' && file.name !== '..') {
                         var filename = task.src + '/' + file.name;
                         if (file.type === 'd') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -271,13 +271,15 @@ Client.prototype.download = function (source, dest, options, downloadCallback) {
     var files = {}, dirs = [];
     var queue = async.queue(function (task, callback) {
         log('Queue worker started for ' + task.src, 'debug');
+        // console.log('Queue worker started for ' + task.src);
         ftp.list(task.src, function (err, list) {
             if (err || typeof list === 'undefined' || typeof list[0] === 'undefined') {
                 throw new Error('The source directory on the server ' + task.src + ' does not exist.');
             }
-
-            if (list && list.length > 1) {
-                _.each(list.splice(1, list.length - 1), function (file) {
+            // if (list && list.length > 0) {
+                // _.each(list.splice(1, list.length - 1), function (file) {
+                _.each(list, function (file) {
+                  console.log('--- file', file);
                     if (file.name !== '.' && file.name !== '..') {
                         var filename = task.src + '/' + file.name;
                         if (file.type === 'd') {
@@ -292,7 +294,7 @@ Client.prototype.download = function (source, dest, options, downloadCallback) {
                         }
                     }
                 });
-            }
+            // }
 
             callback();
         });


### PR DESCRIPTION
throwing error causes whole program to terminate as there's no way to catch it. If you return this error, client program can listen it like: client.ftp.on('error', callback) and act accordingly.
Example:

        client.connect(function() {
          console.log('connected to client');
          client.upload(request.body.fileName, request.body.uploadPath, {
                overwrite: 'older'
            }, function(result) {
            console.log(result);

            response.status(200).json(result);
          });
        });

        client.ftp.on('error', function(err) {
          console.log('--- client error: ', err);
        });
